### PR TITLE
Added missing permission 'user_list_purchased_tickets' to users who wants to view their own tickets

### DIFF
--- a/phoenixRest/views/user/instance/__init__.py
+++ b/phoenixRest/views/user/instance/__init__.py
@@ -121,7 +121,7 @@ class UserInstanceResource(object):
                 (Allow, "%s" % self.userInstance.uuid, 'get_friendship_states'),
                 # Users can fetch their own tickets
                 (Allow, "%s" % self.userInstance.uuid, 'user_list_owned_tickets'),
-                (Allow, "%s" % self.userInstance.uuid, 'user_list_purchased_tickets')
+                (Allow, "%s" % self.userInstance.uuid, 'user_list_purchased_tickets'),
                 (Allow, "%s" % self.userInstance.uuid, 'user_list_seatable_tickets'),
                 # Users can see their own ticket transfers
                 (Allow, "%s" % self.userInstance.uuid, 'user_list_ticket_transfers'),

--- a/phoenixRest/views/user/instance/__init__.py
+++ b/phoenixRest/views/user/instance/__init__.py
@@ -121,6 +121,7 @@ class UserInstanceResource(object):
                 (Allow, "%s" % self.userInstance.uuid, 'get_friendship_states'),
                 # Users can fetch their own tickets
                 (Allow, "%s" % self.userInstance.uuid, 'user_list_owned_tickets'),
+                (Allow, "%s" % self.userInstance.uuid, 'user_list_purchased_tickets')
                 (Allow, "%s" % self.userInstance.uuid, 'user_list_seatable_tickets'),
                 # Users can see their own ticket transfers
                 (Allow, "%s" % self.userInstance.uuid, 'user_list_ticket_transfers'),


### PR DESCRIPTION
Ref. to fix issue #61 

> When a user without admin rights attempts to open the tickets tab on crew.phoenixlan.no/user/X for their own account, an error occurs saying they are missing "user_list_purchased_tickets". they should have this permission, right?